### PR TITLE
day2: remove hardcoded filename

### DIFF
--- a/2020/Day2/validPassword.R
+++ b/2020/Day2/validPassword.R
@@ -1,17 +1,8 @@
-#-------------------
-#clear workspace
-rm(list = ls())
-
 #Libraries
 library(tidyverse)
 
-#Set working directory
-path <- "~/Documents/adventofcode1/adventofcode/2020/Day2"
-setwd(path)
-
 #Load In Data
-file <- "exercise2.input.txt"
-df <- read.table(file, header = FALSE, sep = " ")
+df <- read.table(file("stdin"), header = FALSE, sep = " ")
 
 #-------------------
 #Clean up dataframe


### PR DESCRIPTION
I was unable to run this code because of the hardcoded filenames:
```
❯ Rscript ./validPassword.R
── Attaching packages ─────────────────────────────────────── tidyverse 1.3.0 ──
✔ ggplot2 3.3.2     ✔ purrr   0.3.4
✔ tibble  3.0.3     ✔ dplyr   1.0.2
✔ tidyr   1.1.1     ✔ stringr 1.4.0
✔ readr   1.3.1     ✔ forcats 0.5.0
── Conflicts ────────────────────────────────────────── tidyverse_conflicts() ──
✖ dplyr::filter() masks stats::filter()
✖ dplyr::lag()    masks stats::lag()
Error in setwd(path) : cannot change working directory
Execution halted
```

I updated the program to take input from `STDIN`, and it ran successfully:
```
❯ Rscript ./validPassword.R < exercise2.input.txt
── Attaching packages ─────────────────────────────────────── tidyverse 1.3.0 ──
✔ ggplot2 3.3.2     ✔ purrr   0.3.4
✔ tibble  3.0.3     ✔ dplyr   1.0.2
✔ tidyr   1.1.1     ✔ stringr 1.4.0
✔ readr   1.3.1     ✔ forcats 0.5.0
── Conflicts ────────────────────────────────────────── tidyverse_conflicts() ──
✖ dplyr::filter() masks stats::filter()
✖ dplyr::lag()    masks stats::lag()
There were 50 or more warnings (use warnings() to see the first 50)
[1] 410
[1] 694
```